### PR TITLE
feat(import) Add `Imports.Namespace` to set the current import namespace

### DIFF
--- a/wasmer/import.go
+++ b/wasmer/import.go
@@ -47,18 +47,33 @@ type Import struct {
 
 	// The function implementation signature as a WebAssembly signature.
 	wasmOutputs []cWasmerValueTag
+
+	// The namespace of the imported function.
+	namespace string
 }
 
 // Imports represents a set of imported functions for a WebAssembly instance.
 type Imports struct {
+	// All imports.
 	imports map[string]Import
+
+	// Current namespace where to register the import.
+	currentNamespace string
 }
 
 // NewImports constructs a new empty `Imports`.
 func NewImports() *Imports {
 	var imports = make(map[string]Import)
+	var currentNamespace = "env"
 
-	return &Imports{imports}
+	return &Imports{imports, currentNamespace}
+}
+
+// Namespace changes the current namespace of the next imported functions.
+func (imports *Imports) Namespace(namespace string) *Imports {
+	imports.currentNamespace = namespace
+
+	return imports
 }
 
 // Append adds a new imported function to the current set.
@@ -119,6 +134,7 @@ func (imports *Imports) Append(importName string, implementation interface{}, cg
 	}
 
 	var importedFunctionPointer *cWasmerImportFuncT
+	var namespace = imports.currentNamespace
 
 	imports.imports[importName] = Import{
 		implementation,
@@ -126,6 +142,7 @@ func (imports *Imports) Append(importName string, implementation interface{}, cg
 		importedFunctionPointer,
 		wasmInputs,
 		wasmOutputs,
+		namespace,
 	}
 
 	return imports, nil

--- a/wasmer/instance.go
+++ b/wasmer/instance.go
@@ -108,7 +108,7 @@ func NewInstanceWithImports(bytes []byte, imports *Imports) (Instance, error) {
 		)
 
 		var importedFunction = cNewWasmerImportT(
-			"env",
+			importFunction.namespace,
 			importName,
 			importFunction.importedFunctionPointer,
 		)

--- a/wasmer/test/imports.go
+++ b/wasmer/test/imports.go
@@ -33,7 +33,7 @@ func sum(context unsafe.Pointer, x int32, y int32) int32 {
 }
 
 func testImport(t *testing.T) {
-	imports, err := wasm.NewImports().Append("sum", sum, C.sum)
+	imports, err := wasm.NewImports().Namespace("env").Append("sum", sum, C.sum)
 	assert.NoError(t, err)
 
 	instance, err := wasm.NewInstanceWithImports(getImportedFunctionBytes("examples", "imported_function.wasm"), imports)


### PR DESCRIPTION
Fix #25.

Basically, this patch allows to define imported function in any
namepace. The `Imports.Namespace` sets the current namespce for the
next defined imported functions:

```go
wasm.NewImports().Namespace("ns").Append("f", f, C.f)
```

By default, the namespace is `env`, so both statements are identical:

```go
wasm.NewImports().Namespace("env").Append(…)
wasm.NewImports().Append(…)
```

To register imported functions in different namespaces, one writes:

```go
wasm.NewImports().Namespace("ns1").Append(…).Append(…).Namespace("ns2").Append(…).Append(…)…
```