### PR TITLE
feat(import) Support instance context data

### DIFF
--- a/justfile
+++ b/justfile
@@ -39,7 +39,7 @@ test:
 	#export DYLD_PRINT_LIBRARIES=y
 	cd wasmer/test/
 	# Run the tests.
-	go test -test.v $(find . -type f \( -name "*_test.go" \! -name "example_*.go" \! -name "benchmark*.go" \) ) imports.go
+	GODEBUG=cgocheck=2 go test -test.v $(find . -type f \( -name "*_test.go" \! -name "example_*.go" \! -name "benchmark*.go" \) ) imports.go
 	# Run the short examples.
 	go test -test.v example_test.go
 	# Run the long examples.

--- a/wasmer/bridge.go
+++ b/wasmer/bridge.go
@@ -146,6 +146,14 @@ func cWasmerInstanceContextMemory(instanceContext *cWasmerInstanceContextT) *cWa
 	return (*cWasmerMemoryT)(C.wasmer_instance_context_memory((*C.wasmer_instance_context_t)(instanceContext), 0))
 }
 
+func cWasmerInstanceContextDataSet(instance *cWasmerInstanceT, dataPointer unsafe.Pointer) {
+	C.wasmer_instance_context_data_set((*C.wasmer_instance_t)(instance), dataPointer)
+}
+
+func cWasmerInstanceContextDataGet(instanceContext *cWasmerInstanceContextT) unsafe.Pointer {
+	return unsafe.Pointer(C.wasmer_instance_context_data_get((*C.wasmer_instance_t)(instanceContext)))
+}
+
 func cGoString(string *cChar) string {
 	return C.GoString((*C.char)(string))
 }

--- a/wasmer/import.go
+++ b/wasmer/import.go
@@ -179,7 +179,7 @@ func (instanceContext *InstanceContext) Memory() *Memory {
 }
 
 // Data returns the instance context data as an `unsafe.Pointer`. It's
-// up to the user to cast it appropriately.
+// up to the user to cast it appropriately as a pointer to a data.
 func (instanceContext *InstanceContext) Data() unsafe.Pointer {
 	return cWasmerInstanceContextDataGet(instanceContext.context)
 }

--- a/wasmer/import.go
+++ b/wasmer/import.go
@@ -177,3 +177,9 @@ func IntoInstanceContext(instanceContext unsafe.Pointer) InstanceContext {
 func (instanceContext *InstanceContext) Memory() *Memory {
 	return &instanceContext.memory
 }
+
+// Data returns the instance context data as an `unsafe.Pointer`. It's
+// up to the user to cast it appropriately.
+func (instanceContext *InstanceContext) Data() unsafe.Pointer {
+	return cWasmerInstanceContextDataGet(instanceContext.context)
+}

--- a/wasmer/instance.go
+++ b/wasmer/instance.go
@@ -387,6 +387,12 @@ func NewInstanceWithImports(bytes []byte, imports *Imports) (Instance, error) {
 	return Instance{instance: instance, imports: imports, Exports: exports, Memory: memory}, nil
 }
 
+// SetContextData assigns a data that can be used by all imported
+// functions. Indeed, each imported function receives as its first
+// argument an instance context (see `InstanceContext`). An instance
+// context can hold a pointer to any kind of data. It is important to
+// understand that this data is shared by all imported function, it's
+// global to the instance.
 func (instance *Instance) SetContextData(data unsafe.Pointer) {
 	cWasmerInstanceContextDataSet(instance.instance, data)
 }

--- a/wasmer/instance.go
+++ b/wasmer/instance.go
@@ -387,6 +387,10 @@ func NewInstanceWithImports(bytes []byte, imports *Imports) (Instance, error) {
 	return Instance{instance: instance, imports: imports, Exports: exports, Memory: memory}, nil
 }
 
+func (instance *Instance) SetContextData(data unsafe.Pointer) {
+	cWasmerInstanceContextDataSet(instance.instance, data)
+}
+
 // Close closes/frees an `Instance`.
 func (instance *Instance) Close() {
 	if instance.imports != nil {

--- a/wasmer/test/import_test.go
+++ b/wasmer/test/import_test.go
@@ -36,3 +36,7 @@ func TestImportBadOutput(t *testing.T) {
 func TestImportInstanceContext(t *testing.T) {
 	testImportInstanceContext(t)
 }
+
+func TestImportInstanceContextData(t *testing.T) {
+	testImportInstanceContextData(t)
+}


### PR DESCRIPTION
Fix https://github.com/wasmerio/go-ext-wasm/issues/28.

Example:

```go
//export logMessageWithContextData
func logMessageWithContextData(context unsafe.Pointer, pointer int32, length int32) {
	var instanceContext = wasm.IntoInstanceContext(context)
	var memory = instanceContext.Memory().Data()
	var logMessage = (*logMessageContext)(instanceContext.Data())

	logMessage.message = string(memory[pointer : pointer+length])
}

type logMessageContext struct {
	message string
}

func testImportInstanceContextData(t *testing.T) {
	imports, err := wasm.NewImports().Append("log_message", logMessageWithContextData, C.logMessageWithContextData)
	assert.NoError(t, err)

	instance, err := wasm.NewInstanceWithImports(getImportedFunctionBytes("log.wasm"), imports)
	assert.NoError(t, err)

	defer instance.Close()

	contextData := logMessageContext{message: "first"}
	instance.SetContextData(unsafe.Pointer(&contextData))

	doSomething := instance.Exports["do_something"]

	result, err := doSomething()

	assert.NoError(t, err)
	assert.Equal(t, wasm.TypeVoid, result.GetType())
	assert.Equal(t, "hello", contextData.message)
}
```

1. When defining the instance, we see `SetContextData` that assigns a data to the instance context.
2. In the imported function, on the instance context, we see the `Data` method call that retrieves the instance context data (here, cast as a `logMessageContext` structure).