### PR TITLE
doc(example) Fix example namespaces for `godoc`

### DIFF
--- a/wasmer/test/example_greet_test.go
+++ b/wasmer/test/example_greet_test.go
@@ -1,4 +1,4 @@
-package wasmertest
+package wasmer_test
 
 import (
 	"fmt"

--- a/wasmer/test/example_import_test.go
+++ b/wasmer/test/example_import_test.go
@@ -1,4 +1,4 @@
-package wasmertest
+package wasmer_test
 
 // // 1️⃣ Declare the `sum` function signature (see [cgo](https://golang.org/cmd/cgo/)).
 //

--- a/wasmer/test/example_memory_test.go
+++ b/wasmer/test/example_memory_test.go
@@ -1,4 +1,4 @@
-package wasmertest
+package wasmer_test
 
 import (
 	"fmt"

--- a/wasmer/test/example_simple_test.go
+++ b/wasmer/test/example_simple_test.go
@@ -1,4 +1,4 @@
-package wasmertest
+package wasmer_test
 
 import (
 	"fmt"

--- a/wasmer/test/example_test.go
+++ b/wasmer/test/example_test.go
@@ -1,4 +1,4 @@
-package wasmertest
+package wasmer_test
 
 import (
 	"fmt"


### PR DESCRIPTION
`godoc` needs the `_test` prefix to match the examples to the `wasmer` namespace.