### PR TITLE
feat(module) Add `Compile`, `Module.Instantiate*`, and `Module.Close`

### DIFF
--- a/wasmer/bridge.go
+++ b/wasmer/bridge.go
@@ -24,6 +24,7 @@ type cWasmerImportT C.wasmer_import_t
 type cWasmerInstanceContextT C.wasmer_instance_context_t
 type cWasmerInstanceT C.wasmer_instance_t
 type cWasmerMemoryT C.wasmer_memory_t
+type cWasmerModuleT C.wasmer_module_t
 type cWasmerResultT C.wasmer_result_t
 type cWasmerValueT C.wasmer_value_t
 type cWasmerValueTag C.wasmer_value_tag
@@ -152,6 +153,18 @@ func cWasmerInstanceContextDataSet(instance *cWasmerInstanceT, dataPointer unsaf
 
 func cWasmerInstanceContextDataGet(instanceContext *cWasmerInstanceContextT) unsafe.Pointer {
 	return unsafe.Pointer(C.wasmer_instance_context_data_get((*C.wasmer_instance_t)(instanceContext)))
+}
+
+func cWasmerCompile(module **cWasmerModuleT, wasmBytes *cUchar, wasmBytesLength cUint) cWasmerResultT {
+	return cWasmerResultT(C.wasmer_compile((**C.wasmer_module_t)(unsafe.Pointer(module)), (*C.uchar)(wasmBytes), (C.uint)(wasmBytesLength)))
+}
+
+func cWasmerModuleDestroy(module *cWasmerModuleT) {
+	C.wasmer_module_destroy((*C.wasmer_module_t)(module))
+}
+
+func cWasmerModuleInstantiate(module *cWasmerModuleT, instance **cWasmerInstanceT, imports *cWasmerImportT, importsLength cInt) cWasmerResultT {
+	return cWasmerResultT(C.wasmer_module_instantiate((*C.wasmer_module_t)(module), (**C.wasmer_instance_t)(unsafe.Pointer(instance)), (*C.wasmer_import_t)(imports), (C.int)(importsLength)))
 }
 
 func cGoString(string *cChar) string {

--- a/wasmer/example_test.go
+++ b/wasmer/example_test.go
@@ -33,8 +33,40 @@ func ExampleValidate() {
 	// true
 }
 
-func ExampleInstance_basic() {
+func ExampleCompile() {
+	// Compiles the bytes into a WebAssembly module.
+	module, err := wasm.Compile(GetBytes())
+	defer module.Close()
+
+	_ = err
+}
+
+func ExampleModule_Instantiate() {
+	// Compiles the bytes into a WebAssembly module.
+	module, _ := wasm.Compile(GetBytes())
+	defer module.Close()
+
 	// Instantiates the WebAssembly module.
+	instance, _ := module.Instantiate()
+	defer instance.Close()
+
+	// Gets an exported function.
+	sum, functionExists := instance.Exports["sum"]
+
+	fmt.Println(functionExists)
+
+	// Calls the `sum` exported function with Go values.
+	result, _ := sum(1, 2)
+
+	fmt.Println(result)
+
+	// Output:
+	// true
+	// 3
+}
+
+func ExampleInstance_basic() {
+	// Instantiates a WebAssembly instance from bytes.
 	instance, err := wasm.NewInstance(GetBytes())
 	defer instance.Close()
 
@@ -42,7 +74,7 @@ func ExampleInstance_basic() {
 }
 
 func ExampleInstance_exportedFunctions() {
-	// Instantiates the WebAssembly module.
+	// Instantiates a WebAssembly instance from bytes.
 	instance, _ := wasm.NewInstance(GetBytes())
 	defer instance.Close()
 
@@ -68,7 +100,7 @@ func ExampleInstance_exportedFunctions() {
 }
 
 func ExampleInstance_memory() {
-	// Instantiates the WebAssembly module.
+	// Instantiates a WebAssembly instance from bytes.
 	instance, _ := wasm.NewInstance(GetBytes())
 	defer instance.Close()
 
@@ -90,7 +122,7 @@ func ExampleInstance_memory() {
 }
 
 func ExampleInstance_Close() {
-	// Instantiates the WebAssembly module.
+	// Instantiates a WebAssembly instance from bytes.
 	instance, _ := wasm.NewInstance(GetBytes())
 
 	// Closes/frees the instance (usually used with `defer`).

--- a/wasmer/module.go
+++ b/wasmer/module.go
@@ -15,3 +15,80 @@ func ReadBytes(filename string) ([]byte, error) {
 func Validate(bytes []byte) bool {
 	return true == cWasmerValidate((*cUchar)(unsafe.Pointer(&bytes[0])), cUint(len(bytes)))
 }
+
+// ModuleError represents any kind of errors related to a WebAssembly
+// module.
+type ModuleError struct {
+	// Error message.
+	message string
+}
+
+// NewModuleError constructs a new `ModuleError`.
+func NewModuleError(message string) *ModuleError {
+	return &ModuleError{message}
+}
+
+// `ModuleError` is an actual error. The `Error` function returns the
+// error message.
+func (error *ModuleError) Error() string {
+	return error.message
+}
+
+// Module represents a WebAssembly module.
+type Module struct {
+	module *cWasmerModuleT
+}
+
+// Compile compiles a WebAssembly module from bytes.
+func Compile(bytes []byte) (Module, error) {
+	var module *cWasmerModuleT
+
+	var compileResult = cWasmerCompile(
+		&module,
+		(*cUchar)(unsafe.Pointer(&bytes[0])),
+		cUint(len(bytes)),
+	)
+
+	var emptyModule = Module{module: nil}
+
+	if compileResult != cWasmerOk {
+		return emptyModule, NewModuleError("Failed to compile the module.")
+	}
+
+	return Module{module}, nil
+}
+
+// Instantiate creates a new instance of the WebAssembly module.
+func (module *Module) Instantiate() (Instance, error) {
+	return module.InstantiateWithImports(NewImports())
+}
+
+// InstantiateWithImports creates a new instance with imports of the WebAssembly module.
+func (module *Module) InstantiateWithImports(imports *Imports) (Instance, error) {
+	return newInstanceWithImports(
+		imports,
+		func(wasmImportsCPointer *cWasmerImportT, numberOfImports int) (*cWasmerInstanceT, error) {
+			var instance *cWasmerInstanceT
+
+			var instantiateResult = cWasmerModuleInstantiate(
+				module.module,
+				&instance,
+				wasmImportsCPointer,
+				cInt(numberOfImports),
+			)
+
+			if instantiateResult != cWasmerOk {
+				return nil, NewModuleError("Failed to instantiate the module.")
+			}
+
+			return instance, nil
+		},
+	)
+}
+
+// Close closes/frees a `Module`.
+func (module *Module) Close() {
+	if module.module != nil {
+		cWasmerModuleDestroy(module.module)
+	}
+}

--- a/wasmer/test/import_test.go
+++ b/wasmer/test/import_test.go
@@ -7,8 +7,12 @@ import (
 	"unsafe"
 )
 
-func TestImport(t *testing.T) {
-	testImport(t)
+func TestInstanceImport(t *testing.T) {
+	testInstanceImport(t)
+}
+
+func TestModuleImport(t *testing.T) {
+	testModuleImport(t)
 }
 
 func TestImportNoAFunction(t *testing.T) {

--- a/wasmer/test/instance_test.go
+++ b/wasmer/test/instance_test.go
@@ -37,7 +37,7 @@ func TestInstantiateInvalidModule(t *testing.T) {
 	instance, err := wasm.NewInstance(GetInvalidBytes())
 	defer instance.Close()
 
-	assert.EqualError(t, err, "Failed to compile the module.")
+	assert.EqualError(t, err, "Failed to instantiate the module.")
 }
 
 func TestBasicSum(t *testing.T) {

--- a/wasmer/test/module_test.go
+++ b/wasmer/test/module_test.go
@@ -27,3 +27,33 @@ func TestValidateInvalid(t *testing.T) {
 
 	assert.False(t, output)
 }
+
+func TestCompile(t *testing.T) {
+	module, err := wasm.Compile(GetBytes())
+	defer module.Close()
+
+	assert.NoError(t, err)
+}
+
+func TestCompileInvalidModule(t *testing.T) {
+	module, err := wasm.Compile(GetInvalidBytes())
+	defer module.Close()
+
+	assert.EqualError(t, err, "Failed to compile the module.")
+}
+
+func TestModuleInstantiate(t *testing.T) {
+	module, err := wasm.Compile(GetBytes())
+	defer module.Close()
+
+	assert.NoError(t, err)
+
+	instance, err := module.Instantiate()
+	defer instance.Close()
+
+	assert.NoError(t, err)
+
+	result, _ := instance.Exports["sum"](1, 2)
+
+	assert.Equal(t, wasm.I32(3), result)
+}


### PR DESCRIPTION
Fix #27.

This patch adds a way to build a real `Module` by using the `Compile`
function. Then, a module can instantiated with `Module.Instantiate` or
`Module.InstantiateWithImports`.

The `NewInstanceWithImports` function has been updated to use a new
`newInstanceWithImports` private function that takes an “instance
builder” as a parameter, so that it's easier to share code `Instance`
and `Module` when it comes to create an `Instance` with its imports,
exports, and memory.