### PR TITLE
feat(module) Support export descriptors

### DIFF
--- a/wasmer/bridge.go
+++ b/wasmer/bridge.go
@@ -14,6 +14,8 @@ type cUint C.uint
 type cUint32T C.uint32_t
 type cUint8T C.uint8_t
 type cWasmerByteArray C.wasmer_byte_array
+type cWasmerExportDescriptorT C.wasmer_export_descriptor_t
+type cWasmerExportDescriptorsT C.wasmer_export_descriptors_t
 type cWasmerExportFuncT C.wasmer_export_func_t
 type cWasmerExportT C.wasmer_export_t
 type cWasmerExportsT C.wasmer_exports_t
@@ -33,9 +35,11 @@ type cWasmerValueTag C.wasmer_value_tag
 const cWasmF32 = C.WASM_F32
 const cWasmF64 = C.WASM_F64
 const cWasmFunction = C.WASM_FUNCTION
+const cWasmGlobal = C.WASM_GLOBAL
 const cWasmI32 = C.WASM_I32
 const cWasmI64 = C.WASM_I64
 const cWasmMemory = C.WASM_MEMORY
+const cWasmTable = C.WASM_TABLE
 const cWasmerOk = C.WASMER_OK
 
 func cWasmerLastErrorLength() cInt {
@@ -188,6 +192,30 @@ func cWasmerSerializedModuleFromBytes(serializedModule **cWasmerSerializedModule
 
 func cWasmerSerializedModuleDestroy(serializedModule *cWasmerSerializedModuleT) {
 	C.wasmer_serialized_module_destroy((*C.wasmer_serialized_module_t)(serializedModule))
+}
+
+func cWasmerExportDescriptors(module *cWasmerModuleT, exportDescriptors **cWasmerExportDescriptorsT) {
+	C.wasmer_export_descriptors((*C.wasmer_module_t)(module), (**C.wasmer_export_descriptors_t)(unsafe.Pointer(exportDescriptors)))
+}
+
+func cWasmerExportDescriptorsDestroy(exportDescriptors *cWasmerExportDescriptorsT) {
+	C.wasmer_export_descriptors_destroy((*C.wasmer_export_descriptors_t)(exportDescriptors))
+}
+
+func cWasmerExportDescriptorsLen(exportDescriptors *cWasmerExportDescriptorsT) cInt {
+	return (cInt)(C.wasmer_export_descriptors_len((*C.wasmer_export_descriptors_t)(exportDescriptors)))
+}
+
+func cWasmerExportDescriptorsGet(exportDescriptors *cWasmerExportDescriptorsT, index cInt) *cWasmerExportDescriptorT {
+	return (*cWasmerExportDescriptorT)(C.wasmer_export_descriptors_get((*C.wasmer_export_descriptors_t)(exportDescriptors), (C.int)(index)))
+}
+
+func cWasmerExportDescriptorKind(exportDescriptor *cWasmerExportDescriptorT) cWasmerImportExportKind {
+	return cWasmerImportExportKind(C.wasmer_export_descriptor_kind((*C.wasmer_export_descriptor_t)(exportDescriptor)))
+}
+
+func cWasmerExportDescriptorName(exportDescriptor *cWasmerExportDescriptorT) cWasmerByteArray {
+	return (cWasmerByteArray)(C.wasmer_export_descriptor_name((*C.wasmer_export_descriptor_t)(exportDescriptor)))
 }
 
 func cGoString(string *cChar) string {

--- a/wasmer/module.go
+++ b/wasmer/module.go
@@ -34,18 +34,32 @@ func (error *ModuleError) Error() string {
 	return error.message
 }
 
+// ExportDescriptor represents an export descriptor of a WebAssembly
+// module. It is different of an export of a WebAssembly instance. An
+// export descriptor only has a name and a kind/type.
 type ExportDescriptor struct {
+	// The export name.
 	Name string
+
+	// The export kind/type.
 	Kind ExportKind
 }
 
+// ExportKind represents an export descriptor kind/type.
 type ExportKind int
 
 const (
+	// ExportKindFunction represents an export descriptor of kind function.
 	ExportKindFunction = ExportKind(cWasmFunction)
-	ExportKindGlobal   = ExportKind(cWasmGlobal)
-	ExportKindMemory   = ExportKind(cWasmMemory)
-	ExportKindTable    = ExportKind(cWasmTable)
+
+	// ExportKindGlobal represents an export descriptor of kind global.
+	ExportKindGlobal = ExportKind(cWasmGlobal)
+
+	// ExportKindMemory represents an export descriptor of kind memory.
+	ExportKindMemory = ExportKind(cWasmMemory)
+
+	// ExportKindTable represents an export descriptor of kind table.
+	ExportKindTable = ExportKind(cWasmTable)
 )
 
 // Module represents a WebAssembly module.

--- a/wasmer/test/module_test.go
+++ b/wasmer/test/module_test.go
@@ -94,3 +94,67 @@ func TestModuleDeserializeModuleWithRandomBytes(t *testing.T) {
 
 	assert.EqualError(t, err, "Failed to deserialize the module.")
 }
+
+func TestModuleExports(t *testing.T) {
+	module, _ := wasm.Compile(GetBytes())
+	defer module.Close()
+
+	assert.Equal(
+		t,
+		[]wasm.ExportDescriptor{
+			wasm.ExportDescriptor{
+				Name: "void",
+				Kind: wasm.ExportKindFunction,
+			},
+			wasm.ExportDescriptor{
+				Name: "i32_i64_f32_f64_f64",
+				Kind: wasm.ExportKindFunction,
+			},
+			wasm.ExportDescriptor{
+				Name: "sum",
+				Kind: wasm.ExportKindFunction,
+			},
+			wasm.ExportDescriptor{
+				Name: "__heap_base",
+				Kind: wasm.ExportKindGlobal,
+			},
+			wasm.ExportDescriptor{
+				Name: "arity_0",
+				Kind: wasm.ExportKindFunction,
+			},
+			wasm.ExportDescriptor{
+				Name: "i32_i32",
+				Kind: wasm.ExportKindFunction,
+			},
+			wasm.ExportDescriptor{
+				Name: "memory",
+				Kind: wasm.ExportKindMemory,
+			},
+			wasm.ExportDescriptor{
+				Name: "bool_casted_to_i32",
+				Kind: wasm.ExportKindFunction,
+			},
+			wasm.ExportDescriptor{
+				Name: "__data_end",
+				Kind: wasm.ExportKindGlobal,
+			},
+			wasm.ExportDescriptor{
+				Name: "f32_f32",
+				Kind: wasm.ExportKindFunction,
+			},
+			wasm.ExportDescriptor{
+				Name: "f64_f64",
+				Kind: wasm.ExportKindFunction,
+			},
+			wasm.ExportDescriptor{
+				Name: "string",
+				Kind: wasm.ExportKindFunction,
+			},
+			wasm.ExportDescriptor{
+				Name: "i64_i64",
+				Kind: wasm.ExportKindFunction,
+			},
+		},
+		module.Exports,
+	)
+}


### PR DESCRIPTION
Example:

```go
var module, _ = wasm.Compile(bytes)

assert.Equal(…, "sum", module.Exports[7].Name)
```