### PR TITLE
feat(module) Support import descriptors

### DIFF
--- a/wasmer/bridge.go
+++ b/wasmer/bridge.go
@@ -19,6 +19,8 @@ type cWasmerExportDescriptorsT C.wasmer_export_descriptors_t
 type cWasmerExportFuncT C.wasmer_export_func_t
 type cWasmerExportT C.wasmer_export_t
 type cWasmerExportsT C.wasmer_exports_t
+type cWasmerImportDescriptorT C.wasmer_import_descriptor_t
+type cWasmerImportDescriptorsT C.wasmer_import_descriptors_t
 type cWasmerImportExportKind C.wasmer_import_export_kind
 type cWasmerImportExportValue C.wasmer_import_export_value
 type cWasmerImportFuncT C.wasmer_import_func_t
@@ -216,6 +218,34 @@ func cWasmerExportDescriptorKind(exportDescriptor *cWasmerExportDescriptorT) cWa
 
 func cWasmerExportDescriptorName(exportDescriptor *cWasmerExportDescriptorT) cWasmerByteArray {
 	return (cWasmerByteArray)(C.wasmer_export_descriptor_name((*C.wasmer_export_descriptor_t)(exportDescriptor)))
+}
+
+func cWasmerImportDescriptors(module *cWasmerModuleT, importDescriptors **cWasmerImportDescriptorsT) {
+	C.wasmer_import_descriptors((*C.wasmer_module_t)(module), (**C.wasmer_import_descriptors_t)(unsafe.Pointer(importDescriptors)))
+}
+
+func cWasmerImportDescriptorsDestroy(importDescriptors *cWasmerImportDescriptorsT) {
+	C.wasmer_import_descriptors_destroy((*C.wasmer_import_descriptors_t)(importDescriptors))
+}
+
+func cWasmerImportDescriptorsLen(importDescriptors *cWasmerImportDescriptorsT) cInt {
+	return (cInt)(C.wasmer_import_descriptors_len((*C.wasmer_import_descriptors_t)(importDescriptors)))
+}
+
+func cWasmerImportDescriptorsGet(importDescriptors *cWasmerImportDescriptorsT, index cInt) *cWasmerImportDescriptorT {
+	return (*cWasmerImportDescriptorT)(C.wasmer_import_descriptors_get((*C.wasmer_import_descriptors_t)(importDescriptors), (C.int)(index)))
+}
+
+func cWasmerImportDescriptorKind(importDescriptor *cWasmerImportDescriptorT) cWasmerImportExportKind {
+	return cWasmerImportExportKind(C.wasmer_import_descriptor_kind((*C.wasmer_import_descriptor_t)(importDescriptor)))
+}
+
+func cWasmerImportDescriptorName(importDescriptor *cWasmerImportDescriptorT) cWasmerByteArray {
+	return (cWasmerByteArray)(C.wasmer_import_descriptor_name((*C.wasmer_import_descriptor_t)(importDescriptor)))
+}
+
+func cWasmerImportDescriptorModuleName(importDescriptor *cWasmerImportDescriptorT) cWasmerByteArray {
+	return (cWasmerByteArray)(C.wasmer_import_descriptor_module_name((*C.wasmer_import_descriptor_t)(importDescriptor)))
 }
 
 func cGoString(string *cChar) string {

--- a/wasmer/module.go
+++ b/wasmer/module.go
@@ -62,10 +62,18 @@ const (
 	ImportExportKindTable = ImportExportKind(cWasmTable)
 )
 
+// ImportDescriptor represents an import descriptor of a WebAssembly
+// module. It is different of an import of a WebAssembly instance. An
+// import descriptor only has a name, a namespace, and a kind/type.
 type ImportDescriptor struct {
-	Name      string
+	// The import name.
+	Name string
+
+	// The import namespace.
 	Namespace string
-	Kind      ImportExportKind
+
+	// The import kind/type.
+	Kind ImportExportKind
 }
 
 // Module represents a WebAssembly module.

--- a/wasmer/test/module_test.go
+++ b/wasmer/test/module_test.go
@@ -104,57 +104,86 @@ func TestModuleExports(t *testing.T) {
 		[]wasm.ExportDescriptor{
 			wasm.ExportDescriptor{
 				Name: "void",
-				Kind: wasm.ExportKindFunction,
+				Kind: wasm.ImportExportKindFunction,
 			},
 			wasm.ExportDescriptor{
 				Name: "i32_i64_f32_f64_f64",
-				Kind: wasm.ExportKindFunction,
+				Kind: wasm.ImportExportKindFunction,
 			},
 			wasm.ExportDescriptor{
 				Name: "sum",
-				Kind: wasm.ExportKindFunction,
+				Kind: wasm.ImportExportKindFunction,
 			},
 			wasm.ExportDescriptor{
 				Name: "__heap_base",
-				Kind: wasm.ExportKindGlobal,
+				Kind: wasm.ImportExportKindGlobal,
 			},
 			wasm.ExportDescriptor{
 				Name: "arity_0",
-				Kind: wasm.ExportKindFunction,
+				Kind: wasm.ImportExportKindFunction,
 			},
 			wasm.ExportDescriptor{
 				Name: "i32_i32",
-				Kind: wasm.ExportKindFunction,
+				Kind: wasm.ImportExportKindFunction,
 			},
 			wasm.ExportDescriptor{
 				Name: "memory",
-				Kind: wasm.ExportKindMemory,
+				Kind: wasm.ImportExportKindMemory,
 			},
 			wasm.ExportDescriptor{
 				Name: "bool_casted_to_i32",
-				Kind: wasm.ExportKindFunction,
+				Kind: wasm.ImportExportKindFunction,
 			},
 			wasm.ExportDescriptor{
 				Name: "__data_end",
-				Kind: wasm.ExportKindGlobal,
+				Kind: wasm.ImportExportKindGlobal,
 			},
 			wasm.ExportDescriptor{
 				Name: "f32_f32",
-				Kind: wasm.ExportKindFunction,
+				Kind: wasm.ImportExportKindFunction,
 			},
 			wasm.ExportDescriptor{
 				Name: "f64_f64",
-				Kind: wasm.ExportKindFunction,
+				Kind: wasm.ImportExportKindFunction,
 			},
 			wasm.ExportDescriptor{
 				Name: "string",
-				Kind: wasm.ExportKindFunction,
+				Kind: wasm.ImportExportKindFunction,
 			},
 			wasm.ExportDescriptor{
 				Name: "i64_i64",
-				Kind: wasm.ExportKindFunction,
+				Kind: wasm.ImportExportKindFunction,
 			},
 		},
 		module.Exports,
 	)
+}
+
+func TestModuleImports(t *testing.T) {
+	_, filename, _, _ := runtime.Caller(0)
+	modulePath := path.Join(path.Dir(filename), "testdata", "log.wasm")
+
+	bytes, _ := wasm.ReadBytes(modulePath)
+
+	module, _ := wasm.Compile(bytes)
+	defer module.Close()
+
+	assert.Equal(
+		t,
+		[]wasm.ImportDescriptor{
+			wasm.ImportDescriptor{
+				Name:      "log_message",
+				Namespace: "env",
+				Kind:      wasm.ImportExportKindFunction,
+			},
+		},
+		module.Imports,
+	)
+}
+
+func TestModuleImportsNone(t *testing.T) {
+	module, _ := wasm.Compile(GetBytes())
+	defer module.Close()
+
+	assert.Equal(t, []wasm.ImportDescriptor{}, module.Imports)
 }


### PR DESCRIPTION
Example:

```go
var module, _ = wasm.Compile(bytes)

assert.Equal(…, "log_message", module.Imports[0].Name)
assert.Equal(…, "env", module.Imports[0].Namespace)
```