### PR TITLE
feat(instance,module) Improve error messages

### DIFF
--- a/wasmer/instance.go
+++ b/wasmer/instance.go
@@ -94,7 +94,16 @@ func NewInstanceWithImports(bytes []byte, imports *Imports) (Instance, error) {
 			)
 
 			if compileResult != cWasmerOk {
-				return nil, NewInstanceError("Failed to instantiate the module.")
+				var lastError, err = GetLastError()
+				var errorMessage = "Failed to instantiate the module:\n    %s"
+
+				if err != nil {
+					errorMessage = fmt.Sprintf(errorMessage, "(unknown details)")
+				} else {
+					errorMessage = fmt.Sprintf(errorMessage, lastError)
+				}
+
+				return nil, NewInstanceError(errorMessage)
 			}
 
 			return instance, nil

--- a/wasmer/module.go
+++ b/wasmer/module.go
@@ -1,6 +1,7 @@
 package wasmer
 
 import (
+	"fmt"
 	"io/ioutil"
 	"unsafe"
 )
@@ -174,7 +175,16 @@ func (module *Module) InstantiateWithImports(imports *Imports) (Instance, error)
 			)
 
 			if instantiateResult != cWasmerOk {
-				return nil, NewModuleError("Failed to instantiate the module.")
+				var lastError, err = GetLastError()
+				var errorMessage = "Failed to instantiate the module:\n    %s"
+
+				if err != nil {
+					errorMessage = fmt.Sprintf(errorMessage, "(unknown details)")
+				} else {
+					errorMessage = fmt.Sprintf(errorMessage, lastError)
+				}
+
+				return nil, NewModuleError(errorMessage)
 			}
 
 			return instance, nil

--- a/wasmer/test/import_test.go
+++ b/wasmer/test/import_test.go
@@ -15,6 +15,10 @@ func TestModuleImport(t *testing.T) {
 	testModuleImport(t)
 }
 
+func TestInstanceImportMissingImports(t *testing.T) {
+	testInstanceImportMissingImports(t)
+}
+
 func TestImportNoAFunction(t *testing.T) {
 	_, err := wasm.NewImports().Append("sum", 42, unsafe.Pointer(nil))
 

--- a/wasmer/test/import_test.go
+++ b/wasmer/test/import_test.go
@@ -19,6 +19,10 @@ func TestInstanceImportMissingImports(t *testing.T) {
 	testInstanceImportMissingImports(t)
 }
 
+func TestModuleImportMissingImports(t *testing.T) {
+	testModuleImportMissingImports(t)
+}
+
 func TestImportNoAFunction(t *testing.T) {
 	_, err := wasm.NewImports().Append("sum", 42, unsafe.Pointer(nil))
 

--- a/wasmer/test/imports.go
+++ b/wasmer/test/imports.go
@@ -74,6 +74,12 @@ func testModuleImport(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func testInstanceImportMissingImports(t *testing.T) {
+	_, err := wasm.NewInstance(getImportedFunctionBytes("examples", "imported_function.wasm"))
+
+	assert.EqualError(t, err, "Failed to instantiate the module:\n    link error: Import not found, namespace: env, name: sum")
+}
+
 //export missingContext
 func missingContext() int32 {
 	return 7

--- a/wasmer/test/imports.go
+++ b/wasmer/test/imports.go
@@ -80,6 +80,15 @@ func testInstanceImportMissingImports(t *testing.T) {
 	assert.EqualError(t, err, "Failed to instantiate the module:\n    link error: Import not found, namespace: env, name: sum")
 }
 
+func testModuleImportMissingImports(t *testing.T) {
+	module, _ := wasm.Compile(getImportedFunctionBytes("examples", "imported_function.wasm"))
+	defer module.Close()
+
+	_, err := module.Instantiate()
+
+	assert.EqualError(t, err, "Failed to instantiate the module:\n    error instantiating from module")
+}
+
 //export missingContext
 func missingContext() int32 {
 	return 7

--- a/wasmer/test/instance_test.go
+++ b/wasmer/test/instance_test.go
@@ -37,7 +37,7 @@ func TestInstantiateInvalidModule(t *testing.T) {
 	instance, err := wasm.NewInstance(GetInvalidBytes())
 	defer instance.Close()
 
-	assert.EqualError(t, err, "Failed to instantiate the module.")
+	assert.EqualError(t, err, "Failed to instantiate the module:\n    compile error: Validation error \"Invalid type\"")
 }
 
 func TestBasicSum(t *testing.T) {


### PR DESCRIPTION
Fix #41.

These patches improve error messages when instantiating a module with `Module.Instantiate` or with `NewInstance`.

The error message that is returned by `Module.Instantiate` isn't very helpful, but it's going to change with https://github.com/wasmerio/wasmer/pull/493. Let's wait the next release of the runtime!