### PR TITLE
Update build instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,10 +224,14 @@ To build both parts, run the following commands:
 
 ```sh
 $ just rust
-$ just go
+$ just build
 ```
 
 To build the Go part, run:
+
+```sh
+$ just build
+```
 
 (Yes, you need [`just`]).
 


### PR DESCRIPTION
The current instructions read:

```
just rust
just go
```

`just go` doesn't work, but `just build` and `just build-bin` do.
I updated this to reflect the current state. If the justfile should be changed instead, feel free to reject this PR.