### PR TITLE
feat(InstanceContext): Avoid passing illegal pointers across CGo FFI …

### DIFF
--- a/wasmer/import.go
+++ b/wasmer/import.go
@@ -178,8 +178,11 @@ func (instanceContext *InstanceContext) Memory() *Memory {
 	return &instanceContext.memory
 }
 
-// Data returns the instance context data as an `unsafe.Pointer`. It's
-// up to the user to cast it appropriately as a pointer to a data.
-func (instanceContext *InstanceContext) Data() unsafe.Pointer {
-	return cWasmerInstanceContextDataGet(instanceContext.context)
+// Data returns the instance context data as an `interface{}`. It's up to the
+// user to assert the proper type.
+func (instanceContext *InstanceContext) Data() interface{} {
+	ctxDataIdx := *(*int)(cWasmerInstanceContextDataGet(instanceContext.context))
+	ctxDataMtx.RLock()
+	defer ctxDataMtx.RUnlock()
+	return ctxData[ctxDataIdx]
 }

--- a/wasmer/test/imports.go
+++ b/wasmer/test/imports.go
@@ -226,7 +226,7 @@ func testImportInstanceContext(t *testing.T) {
 func logMessageWithContextData(context unsafe.Pointer, pointer int32, length int32) {
 	var instanceContext = wasm.IntoInstanceContext(context)
 	var memory = instanceContext.Memory().Data()
-	var logMessage = (*logMessageContext)(instanceContext.Data())
+	var logMessage = instanceContext.Data().(*logMessageContext)
 
 	logMessage.message = string(memory[pointer : pointer+length])
 }
@@ -245,7 +245,7 @@ func testImportInstanceContextData(t *testing.T) {
 	defer instance.Close()
 
 	contextData := logMessageContext{message: "first"}
-	instance.SetContextData(unsafe.Pointer(&contextData))
+	instance.SetContextData(&contextData)
 
 	doSomething := instance.Exports["do_something"]
 


### PR DESCRIPTION
…for user data

Previously an unsafe.Pointer to user data was passed across the CGo FFI
which resulted in a panic if the user data included any other Go
pointers. This commit adds a global ctxData registry and assigns a
unique int id to each Instance that calls SetContextData. This id is
stored in the actual C Instance Context Data that crosses the CGo FFI
and is used to look up the actual user data. A sync.RWMutex is used to
synchronize access to the ctxData map.

BREAKING CHANGE: This changes the API for Instance.SetContextData and
InstanceContext.Data to accept and return an interface{} instead of an
unsafe.Pointer.

re #44

### Additional details

This approach is an improvement on the approach being used in the [Gossamer project's](https://github.com/ChainSafe/gossamer) runtime package.

I believe the work around for this limitation should be built directly into this package, because while it is fairly simple, there are subtleties that are easy to miss.

At minimum, the documentation of `Instance.SetContextData()` should be updated to mention this limitation. Issue #44 is an example of confusion about this limitation.