### PR TITLE
feat(InstanceContext): Allow any type of user data

### DIFF
--- a/wasmer/import.go
+++ b/wasmer/import.go
@@ -181,5 +181,6 @@ func (instanceContext *InstanceContext) Memory() *Memory {
 // Data returns the instance context data as an `unsafe.Pointer`. It's
 // up to the user to cast it appropriately as a pointer to a data.
 func (instanceContext *InstanceContext) Data() unsafe.Pointer {
-	return cWasmerInstanceContextDataGet(instanceContext.context)
+	dataPtr := *(*uintptr)(cWasmerInstanceContextDataGet(instanceContext.context))
+	return unsafe.Pointer(dataPtr)
 }

--- a/wasmer/import.go
+++ b/wasmer/import.go
@@ -180,7 +180,8 @@ func (instanceContext *InstanceContext) Memory() *Memory {
 
 // Data returns the instance context data as an `unsafe.Pointer`. It's
 // up to the user to cast it appropriately as a pointer to a data.
-func (instanceContext *InstanceContext) Data() unsafe.Pointer {
-	dataPtr := *(*uintptr)(cWasmerInstanceContextDataGet(instanceContext.context))
-	return unsafe.Pointer(dataPtr)
+func (instanceContext *InstanceContext) Data() interface{} {
+	dataPtr := *(*unsafe.Pointer)(
+		cWasmerInstanceContextDataGet(instanceContext.context))
+	return *(*interface{})(dataPtr)
 }

--- a/wasmer/test/imports.go
+++ b/wasmer/test/imports.go
@@ -226,7 +226,7 @@ func testImportInstanceContext(t *testing.T) {
 func logMessageWithContextData(context unsafe.Pointer, pointer int32, length int32) {
 	var instanceContext = wasm.IntoInstanceContext(context)
 	var memory = instanceContext.Memory().Data()
-	var logMessage = (*logMessageContext)(instanceContext.Data())
+	var logMessage = instanceContext.Data().(*logMessageContext)
 
 	logMessage.message = string(memory[pointer : pointer+length])
 }
@@ -252,7 +252,7 @@ func testImportInstanceContextData(t *testing.T) {
 	contextData := logMessageContext{message: "first",
 		slice: []string{str, str},
 		ptr:   &str}
-	instance.SetContextData(unsafe.Pointer(&contextData))
+	instance.SetContextData(&contextData)
 
 	doSomething := instance.Exports["do_something"]
 

--- a/wasmer/test/imports.go
+++ b/wasmer/test/imports.go
@@ -233,6 +233,10 @@ func logMessageWithContextData(context unsafe.Pointer, pointer int32, length int
 
 type logMessageContext struct {
 	message string
+
+	// Ensure that Context Data may include Go pointers & reference types.
+	slice []string
+	ptr   *string
 }
 
 func testImportInstanceContextData(t *testing.T) {
@@ -244,7 +248,10 @@ func testImportInstanceContextData(t *testing.T) {
 
 	defer instance.Close()
 
-	contextData := logMessageContext{message: "first"}
+	str := "test"
+	contextData := logMessageContext{message: "first",
+		slice: []string{str, str},
+		ptr:   &str}
 	instance.SetContextData(unsafe.Pointer(&contextData))
 
 	doSomething := instance.Exports["do_something"]


### PR DESCRIPTION
Previously the given unsafe.Pointer to user data was passed directly
across the CGo FFI resulting in a panic for any reference types or types
that included any reference types or other Go pointers.

This commit avoids a panic by casting the unsafe.Pointer to a uintptr,
which is not analyzed by the runtime. In order for compatability with
the existing CGo API and bridge code, which expects (void*), a *uintptr
is passed. The memory for the user provided unsafe.Pointer and the
*uintptr is cached in the instance to protect it from garbage
collection.

The tests are expanded to ensure that reference types do not cause
panics.

re #44 #83