### PR TITLE
fix(InstanceContext): Don't use uintptr for Data

### DIFF
--- a/wasmer/import.go
+++ b/wasmer/import.go
@@ -338,10 +338,11 @@ func (instanceContext *InstanceContext) Memory() *Memory {
 	return &instanceContext.memory
 }
 
-// Data returns the instance context data as an `interface{}`. It's
-// up to the user to cast it appropriately.
+// Data returns the instance context data as an `interface{}`. It's up to the
+// user to assert the proper type.
 func (instanceContext *InstanceContext) Data() interface{} {
-	dataPtr := *(*unsafe.Pointer)(cWasmerInstanceContextDataGet(instanceContext.context))
-
-	return *(*interface{})(dataPtr)
+	ctxDataIdx := *(*int)(cWasmerInstanceContextDataGet(instanceContext.context))
+	ctxDataMtx.RLock()
+	defer ctxDataMtx.RUnlock()
+	return ctxData[ctxDataIdx]
 }


### PR DESCRIPTION
Previously an uintptr to user data was passed across the CGo FFI which
would become invalid if any stack frame occurred. This commit avoids
this by never passing any pointers across the CGo FFI. A registry map is
used instead to keep Go data on the Go side, and only an int index into
the map is passed across to the C side.

fix #93
re #44 #85 #83