### PR TITLE
feat(import) Implement `Trap` (`wasmer_trap` in C)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ categories = ["wasm"]
 crate-type = ["cdylib"]
 
 [dependencies]
-wasmer-runtime-c-api = "0.12.0"
+wasmer-runtime-c-api = { git = "https://github.com/wasmerio/wasmer", branch = "master" }

--- a/wasmer/bridge.go
+++ b/wasmer/bridge.go
@@ -644,6 +644,16 @@ func cWasmerSerializedModuleFromBytes(
 	))
 }
 
+func cWasmerTrap(
+	instanceContext *cWasmerInstanceContextT,
+	errorMessage string,
+) cWasmerResultT {
+	return (cWasmerResultT)(C.wasmer_trap(
+		(*C.wasmer_instance_context_t)(instanceContext),
+		(*C.char)(cCString(errorMessage)),
+	))
+}
+
 func cWasmerValidate(wasmBytes *cUchar, wasmBytesLength cUint) cBool {
 	return (cBool)(C.wasmer_validate(
 		(*C.uchar)(wasmBytes),

--- a/wasmer/import.go
+++ b/wasmer/import.go
@@ -348,3 +348,10 @@ func (instanceContext *InstanceContext) Data() interface{} {
 
 	return instancesContextData[contextDataIndex]
 }
+
+// Trap bla bla
+func Trap(instanceContext *InstanceContext, errorMessage string) bool {
+	result := cWasmerTrap(instanceContext.context, errorMessage)
+
+	return result == cWasmerOk
+}

--- a/wasmer/test/import_test.go
+++ b/wasmer/test/import_test.go
@@ -60,3 +60,7 @@ func TestImportInstanceContextData(t *testing.T) {
 func TestWasiImportObject(t *testing.T) {
 	testWasiImportObject(t)
 }
+
+func TestImportTrap(t *testing.T) {
+	testImportTrap(t)
+}

--- a/wasmer/wasmer.h
+++ b/wasmer/wasmer.h
@@ -1,17 +1,30 @@
 
 #if !defined(WASMER_H_MACROS)
+
 #define WASMER_H_MACROS
 
-#if defined(MSVC)
-#if defined(_M_AMD64)
-#define ARCH_X86_64
-#endif
+// Define the `ARCH_X86_X64` constant.
+#if defined(MSVC) && defined(_M_AMD64)
+#  define ARCH_X86_64
+#elif (defined(GCC) || defined(__GNUC__) || defined(__clang__)) && defined(__x86_64__)
+#  define ARCH_X86_64
 #endif
 
-#if defined(GCC) || defined(__GNUC__) || defined(__clang__)
-#if defined(__x86_64__)
-#define ARCH_X86_64
+// Compatibility with non-Clang compilers.
+#if !defined(__has_attribute)
+#  define __has_attribute(x) 0
 #endif
+
+// Compatibility with non-Clang compilers.
+#if !defined(__has_declspec_attribute)
+#  define __has_declspec_attribute(x) 0
+#endif
+
+// Define the `DEPRECATED` macro.
+#if defined(GCC) || defined(__GNUC__) || __has_attribute(deprecated)
+#  define DEPRECATED(message) __attribute__((deprecated(message)))
+#elif defined(MSVC) || __has_declspec_attribute(deprecated)
+#  define DEPRECATED(message) __declspec(deprecated(message))
 #endif
 
 #define WASMER_WASI_ENABLED
@@ -34,7 +47,7 @@ enum Version {
   Unknown = 0,
   /**
    * Latest version. See `wasmer_wasi::WasiVersion::Latest` to
-   * leran more.
+   * learn more.
    */
   Latest = 1,
   /**
@@ -524,9 +537,23 @@ unsigned int wasmer_import_descriptors_len(wasmer_import_descriptors_t *exports)
 void wasmer_import_func_destroy(wasmer_import_func_t *func);
 
 /**
- * Creates new func
+ * Creates new host function, aka imported function. `func` is a
+ * function pointer, where the first argument is the famous `vm::Ctx`
+ * (in Rust), or `wasmer_instance_context_t` (in C). All arguments
+ * must be typed with compatible WebAssembly native types:
  *
- * The caller owns the object and should call `wasmer_import_func_destroy` to free it.
+ * | WebAssembly type | C/C++ type |
+ * | ---------------- | ---------- |
+ * | `i32`            | `int32_t`  |
+ * | `i64`            | `int64_t`  |
+ * | `f32`            | `float`    |
+ * | `f64`            | `double`   |
+ *
+ * The function pointer must have a lifetime greater than the
+ * WebAssembly instance lifetime.
+ *
+ * The caller owns the object and should call
+ * `wasmer_import_func_destroy` to free it.
  */
 wasmer_import_func_t *wasmer_import_func_new(void (*func)(void *data),
                                              const wasmer_value_tag *params,
@@ -952,6 +979,24 @@ const wasmer_trampoline_callable_t *wasmer_trampoline_buffer_get_trampoline(cons
  */
 void *wasmer_trampoline_get_context(void);
 #endif
+
+/**
+ * Stop the execution of a host function, aka imported function. The
+ * function must be used _only_ inside a host function.
+ *
+ * The pointer to `wasmer_instance_context_t` is received by the host
+ * function as its first argument. Just passing it to `ctx` is fine.
+ *
+ * The error message must have a greater lifetime than the host
+ * function itself since the error is read outside the host function
+ * with `wasmer_last_error_message`.
+ *
+ * This function returns `wasmer_result_t::WASMER_ERROR` if `ctx` or
+ * `error_message` are null.
+ *
+ * This function never returns otherwise.
+ */
+wasmer_result_t wasmer_trap(const wasmer_instance_context_t *ctx, const char *error_message);
 
 /**
  * Returns true for valid wasm bytes and false for invalid bytes


### PR DESCRIPTION
Fix #58.

When testing, I get this error:

```
=== RUN   TestImportTrap
fatal error: exitsyscall: syscall frame is no longer valid

goroutine 30 [syscall, locked to thread]:
runtime.cgocall(0x42a1990, 0xc000171b00, 0x5)
        /usr/local/Cellar/go/1.12.8/libexec/src/runtime/cgocall.go:128 +0x5b fp=0xc000171ad0 sp=0xc000171a98 pc=0x40059cb
github.com/wasmerio/go-ext-wasm/wasmer._Cfunc_wasmer_trap(0x4a0bc90, 0x4a0b0f0, 0x0)
        _cgo_gotypes.go:1012 +0x4d fp=0xc000171b00 sp=0xc000171ad0 pc=0x429009d
github.com/wasmerio/go-ext-wasm/wasmer.cWasmerTrap(0x4a0bc90, 0x434569b, 0x5, 0x1)
        /Users/hywan/Development/Wasmer/go-ext-wasm/wasmer/bridge.go:651 +0x4e fp=0xc000171b28 sp=0xc000171b00 pc=0x42910de
github.com/wasmerio/go-ext-wasm/wasmer.Trap(...)
        /Users/hywan/Development/Wasmer/go-ext-wasm/wasmer/import.go:354
command-line-arguments.trap(0x4a0bc90, 0x200000001, 0x7ffeefbfe0d8)
        /Users/hywan/Development/Wasmer/go-ext-wasm/wasmer/test/imports.go:300 +0x4f fp=0xc000171b58 sp=0xc000171b28 pc=0x429feaf
command-line-arguments._cgoexpwrap_cadc0fd800d6_trap(0x4a0bc90, 0x200000001, 0x0)
        _cgo_gotypes.go:229 +0x3b fp=0xc000171b80 sp=0xc000171b58 pc=0x429ca2b
runtime.call32(0x0, 0x7ffeefbfde10, 0x7ffeefbfdea8, 0x18)
        /usr/local/Cellar/go/1.12.8/libexec/src/runtime/asm_amd64.s:519 +0x3b fp=0xc000171bb0 sp=0xc000171b80 pc=0x405c06b
runtime: unexpected return pc for runtime.cgocallbackg1 called from 0xc000171c28
stack: frame={sp:0xc000171bb0, fp:0xc000171c28} stack=[0xc000171000,0xc000172000)
000000c000171ab0:  0000000004a0b0f0  00000000045c4c00
000000c000171ac0:  000000c000171af0  000000000429009d <github.com/wasmerio/go-ext-wasm/wasmer._Cfunc_wasmer_trap+77>
000000c000171ad0:  00000000042a1990  000000c000171b00
000000c000171ae0:  0000000000000005  000000c000171b00
000000c000171af0:  000000c000171b18  00000000042910de <github.com/wasmerio/go-ext-wasm/wasmer.cWasmerTrap+78>
000000c000171b00:  0000000004a0bc90  0000000004a0b0f0
000000c000171b10:  0000000000000000  000000c000171b48
000000c000171b20:  000000000429feaf <command-line-arguments.trap+79>  0000000004a0bc90
000000c000171b30:  000000000434569b  0000000000000005
000000c000171b40:  0000000000000001  000000c000171b70
000000c000171b50:  000000000429ca2b <command-line-arguments._cgoexpwrap_cadc0fd800d6_trap+59>  0000000004a0bc90
000000c000171b60:  0000000200000001  00007ffeefbfe0d8
000000c000171b70:  000000c000171ba0  000000000405c06b <runtime.call32+59>
000000c000171b80:  0000000004a0bc90  0000000200000001
000000c000171b90:  0000000000000000  000000c000171bb8
000000c000171ba0:  000000c000171c18  0000000004005d37 <runtime.cgocallbackg1+375>
000000c000171bb0: <0000000000000000  00007ffeefbfde10
000000c000171bc0:  00007ffeefbfdea8  0000000000000018
000000c000171bd0:  000000c0000bac00  0000000004006b55 <runtime.cgoIsGoPointer+37>
000000c000171be0:  000000000435b600  000000c000171c18
000000c000171bf0:  01000000040381d4  000000c000084f00
000000c000171c00:  0000000200000003  000000c000084f00
000000c000171c10:  000000c000084f00  000000000402f8a7 <runtime.fatalthrow+87>
000000c000171c20: !000000c000171c28 >000000000405aa20 <runtime.fatalthrow.func1+0>
000000c000171c30:  000000c000084f00  000000000402f6d2 <runtime.throw+114>
000000c000171c40:  000000c000171c58  000000c000171c78
000000c000171c50:  000000000402f6d2 <runtime.throw+114>  000000c000171c60
000000c000171c60:  000000000405a9a0 <runtime.throw.func1+0>  000000000435289e
000000c000171c70:  000000000000002d  000000c000171ca8
000000c000171c80:  00000000040382b7 <runtime.exitsyscall+647>  000000000435289e
000000c000171c90:  000000000000002d  00000000045c4c00
000000c000171ca0:  000000c000171cb8  000000c000171ce0
000000c000171cb0:  0000000004005a0e <runtime.cgocall+158>  00000000042a1530
000000c000171cc0:  000000c000171d20  0000000000000000
000000c000171cd0:  00000000000000a2  00000000045c4c00
000000c000171ce0:  000000c000171d10  000000000428f3bd <github.com/wasmerio/go-ext-wasm/wasmer._Cfunc_wasmer_instance_call+77>
000000c000171cf0:  00000000042a1530  000000c000171d20
000000c000171d00:  0000000000000004  000000c000171d20
000000c000171d10:  000000c000171ea8  00000000042917e4 <github.com/wasmerio/go-ext-wasm/wasmer.getExportsFromInstance.func1+820>
000000c000171d20:  0000000004a0b6c0
runtime.cgocallbackg1(0x405aa20)
        /usr/local/Cellar/go/1.12.8/libexec/src/runtime/cgocall.go:314 +0x177 fp=0xc000171c28 sp=0xc000171bb0 pc=0x4005d37
created by testing.(*T).Run
        /usr/local/Cellar/go/1.12.8/libexec/src/testing/testing.go:916 +0x35a

goroutine 1 [chan receive]:
testing.(*T).Run(0xc00014a500, 0x4347c08, 0xe, 0x435b218, 0x1)
        /usr/local/Cellar/go/1.12.8/libexec/src/testing/testing.go:917 +0x381
testing.runTests.func1(0xc00012a000)
        /usr/local/Cellar/go/1.12.8/libexec/src/testing/testing.go:1157 +0x78
testing.tRunner(0xc00012a000, 0xc0000cfe30)
        /usr/local/Cellar/go/1.12.8/libexec/src/testing/testing.go:865 +0xc0
testing.runTests(0xc0000b23e0, 0x45bf920, 0x33, 0x33, 0x0)
        /usr/local/Cellar/go/1.12.8/libexec/src/testing/testing.go:1155 +0x2a9
testing.(*M).Run(0xc000126000, 0x0)
        /usr/local/Cellar/go/1.12.8/libexec/src/testing/testing.go:1072 +0x162
main.main()
        _testmain.go:142 +0x13e
FAIL    command-line-arguments  0.226s
```

I think it's because we use `setjmp` to raise an error, and Go also uses it for another purpose. Need to investigate.