### PR TITLE
Fix an off-by-one allocation error in the Greet example

### DIFF
--- a/wasmer/example_greet_test.go
+++ b/wasmer/example_greet_test.go
@@ -25,7 +25,7 @@ func Example_greet() {
 	lengthOfSubject := len(subject)
 
 	// Allocate memory for the subject, and get a pointer to it.
-	allocateResult, _ := instance.Exports["allocate"](lengthOfSubject)
+	allocateResult, _ := instance.Exports["allocate"](lengthOfSubject+1)
 	inputPointer := allocateResult.ToI32()
 
 	// Write the subject into the memory.
@@ -62,8 +62,8 @@ func Example_greet() {
 
 	// Deallocate the subject, and the output.
 	deallocate := instance.Exports["deallocate"]
-	deallocate(inputPointer, lengthOfSubject)
-	deallocate(outputPointer, lengthOfOutput)
+	deallocate(inputPointer, lengthOfSubject+1)
+	deallocate(outputPointer, lengthOfOutput+1)
 
 	// Output:
 	// Hello, Wasmer 🐹!
@@ -85,7 +85,7 @@ func Test_greetLong(t *testing.T) {
 	lengthOfSubject := len(subject)
 
 	// Allocate memory for the subject, and get a pointer to it.
-	allocateResult, _ := instance.Exports["allocate"](lengthOfSubject)
+	allocateResult, _ := instance.Exports["allocate"](lengthOfSubject+1)
 	inputPointer := allocateResult.ToI32()
 
 	// Write the subject into the memory.
@@ -101,7 +101,7 @@ func Test_greetLong(t *testing.T) {
 	// Allocate and copy the input string a second time.
 
 	// Allocate memory for the subject, and get a pointer to it.
-	allocateResult, _ = instance.Exports["allocate"](lengthOfSubject)
+	allocateResult, _ = instance.Exports["allocate"](lengthOfSubject+1)
 	inputPointer2 := allocateResult.ToI32()
 
 	// Write the subject into the memory.
@@ -136,9 +136,9 @@ func Test_greetLong(t *testing.T) {
 
 	// Deallocate the subject, and the output.
 	deallocate := instance.Exports["deallocate"]
-	deallocate(inputPointer, lengthOfSubject)
-	deallocate(inputPointer2, lengthOfSubject)
-	deallocate(outputPointer, lengthOfOutput)
+	deallocate(inputPointer, lengthOfSubject+1)
+	deallocate(inputPointer2, lengthOfSubject+1)
+	deallocate(outputPointer, lengthOfOutput+1)
 
 	expected := "Hello, " + string(subject) + "!"
 	if output.String() != expected {

--- a/wasmer/example_greet_test.go
+++ b/wasmer/example_greet_test.go
@@ -24,15 +24,13 @@ func Example_greet() {
 	lengthOfSubject := len(subject)
 
 	// Allocate memory for the subject, and get a pointer to it.
+	// Include a byte for the NULL terminator we add below.
 	allocateResult, _ := instance.Exports["allocate"](lengthOfSubject+1)
 	inputPointer := allocateResult.ToI32()
 
 	// Write the subject into the memory.
 	memory := instance.Memory.Data()[inputPointer:]
-
-	for nth := 0; nth < lengthOfSubject; nth++ {
-		memory[nth] = subject[nth]
-	}
+	copy(memory, subject)
 
 	// C-string terminates by NULL.
 	memory[lengthOfSubject] = 0

--- a/wasmer/example_greet_test.go
+++ b/wasmer/example_greet_test.go
@@ -6,6 +6,7 @@ import (
 	"path"
 	"runtime"
 	"strings"
+	"testing"
 )
 
 func greetWasmFile() string {
@@ -66,4 +67,81 @@ func Example_greet() {
 
 	// Output:
 	// Hello, Wasmer 🐹!
+}
+
+// Same, but demonstrate an allocation error by using the same string copying logic twice in a row,
+// and using a string long enough so we're near the block boundary.
+func Test_greetLong(t *testing.T) {
+	// Instantiate the module.
+	bytes, _ := wasm.ReadBytes(greetWasmFile())
+	instance, _ := wasm.NewInstance(bytes)
+	defer instance.Close()
+
+	// Set the subject to greet.
+	subject := make([]byte, 1<<16-52)
+	for i := 0; i < len(subject); i++ {
+		subject[i] = 'x'
+	}
+	lengthOfSubject := len(subject)
+
+	// Allocate memory for the subject, and get a pointer to it.
+	allocateResult, _ := instance.Exports["allocate"](lengthOfSubject)
+	inputPointer := allocateResult.ToI32()
+
+	// Write the subject into the memory.
+	memory := instance.Memory.Data()[inputPointer:]
+
+	for nth := 0; nth < lengthOfSubject; nth++ {
+		memory[nth] = subject[nth]
+	}
+
+	// C-string terminates by NULL.
+	memory[lengthOfSubject] = 0
+
+	// Allocate and copy the input string a second time.
+
+	// Allocate memory for the subject, and get a pointer to it.
+	allocateResult, _ = instance.Exports["allocate"](lengthOfSubject)
+	inputPointer2 := allocateResult.ToI32()
+
+	// Write the subject into the memory.
+	memory = instance.Memory.Data()[inputPointer2:]
+
+	for nth := 0; nth < lengthOfSubject; nth++ {
+		memory[nth] = subject[nth]
+	}
+
+	// C-string terminates by NULL.
+	memory[lengthOfSubject] = 0
+
+	// Run the `greet` function. Given the pointer to the subject (the *first* input we copied).
+	greetResult, _ := instance.Exports["greet"](inputPointer)
+	outputPointer := greetResult.ToI32()
+
+	// Read the result of the `greet` function.
+	memory = instance.Memory.Data()[outputPointer:]
+	nth := 0
+	var output strings.Builder
+
+	for {
+		if memory[nth] == 0 {
+			break
+		}
+
+		output.WriteByte(memory[nth])
+		nth++
+	}
+
+	lengthOfOutput := nth
+
+	// Deallocate the subject, and the output.
+	deallocate := instance.Exports["deallocate"]
+	deallocate(inputPointer, lengthOfSubject)
+	deallocate(inputPointer2, lengthOfSubject)
+	deallocate(outputPointer, lengthOfOutput)
+
+	expected := "Hello, " + string(subject) + "!"
+	if output.String() != expected {
+		t.Errorf("Bad output, got %q", output.String()[:10] + "..." + output.String()[lengthOfOutput-10:])
+	}
 }


### PR DESCRIPTION
The Greet example allocates and deallocates memory for a string, but doesn't account for the extra NULL character.

In the first commit I added a demo test that uses the same allocation idiom but also copies a second string. Interestingly, this only fails for a precisely tuned value of the string length (2^16-52), presumably related to hitting the end of a memory block, but I suspect with a little effort other bad effects could be discovered.