### PR TITLE
test(ci) Test with Go 1.14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13'
+          go-version: '1.14'
 
       - name: Set up Rust
         shell: bash


### PR DESCRIPTION
This PR updates Go from 1.13 to 1.14 on the CI testing server.